### PR TITLE
fix: Adds handling of undefined lists when showing popup and webview

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -13,11 +13,11 @@ export type RequirementsToolOutput = {
     requirements: RequirementsMap
     svcs: SVCsMap
     mvrs: MVRsMap
-    reqs_from_urn: StringArrayMap
-    svcs_from_urn: StringArrayMap
-    svcs_from_req: StringArrayMap
-    mvrs_from_urn: StringArrayMap
-    mvrs_from_svc: StringArrayMap
+    reqs_from_urn?: StringArrayMap
+    svcs_from_urn?: StringArrayMap
+    svcs_from_req?: StringArrayMap
+    mvrs_from_urn?: StringArrayMap
+    mvrs_from_svc?: StringArrayMap
 }
 
 /**

--- a/src/ui/HTML.ts
+++ b/src/ui/HTML.ts
@@ -2,13 +2,13 @@
 
 import { RequirementsToolOutput } from '../types'
 import { AnnotationType } from '../enums/AnnotationType'
-import { stringifyRevision } from '../util'
+import { ensureStringArray, stringifyRevision } from '../util'
 
 export namespace HTML {
     export function fromRequirement(urn: string, reqstoolData: RequirementsToolOutput, workspaceKey: string) {
         const { id, title, significance, revision, description, rationale, categories } = reqstoolData.requirements[urn]
         const categoryItems = categories.map((cat) => /*html*/ `<li>${cat}</li>`).join('\n')
-        const linked = reqstoolData.svcs_from_req[id]
+        const linked = ensureStringArray(reqstoolData.svcs_from_req?.[id])
             .map((svc) => /*html*/ `<li>${link(svc, AnnotationType.svc, workspaceKey)}</li>`)
             .join('\n')
         return wrapInBaseTemplate(/*html*/ `
@@ -35,7 +35,7 @@ export namespace HTML {
         const reqIds = requirement_ids
             .map((req) => /*html*/ `<li>${link(req, AnnotationType.requirement, workspaceKey)}</li>`)
             .join('\n')
-        const relatedMvrs = reqstoolData.mvrs_from_svc[id]
+        const relatedMvrs = ensureStringArray(reqstoolData.mvrs_from_svc?.[id])
             .map((mvr) => /*html*/ `<li>${link(mvr, AnnotationType.mvr, workspaceKey)}</li>`)
             .join('\n')
 

--- a/src/ui/Markdown.ts
+++ b/src/ui/Markdown.ts
@@ -3,11 +3,14 @@
 import { MarkdownString } from 'vscode'
 import { AnnotationType } from '../enums/AnnotationType'
 import { HoverClickHandlerArgs, RequirementsToolOutput } from '../types'
-import { stringifyRevision } from '../util'
+import { ensureStringArray, stringifyRevision } from '../util'
 
 export namespace Markdown {
     export function fromRequirement(urn: string, reqstoolData: RequirementsToolOutput, workspaceKey: string) {
         const { id, title, significance, revision, description, rationale, categories } = reqstoolData.requirements[urn]
+        const svcLinks = ensureStringArray(reqstoolData.svcs_from_req?.[urn]).map((svc) =>
+            link(svc, AnnotationType.svc, workspaceKey)
+        )
         const lines = [
             `### ${title}`,
             `\`${id}\` \`${significance}\` \`${stringifyRevision(revision)}\``,
@@ -18,8 +21,7 @@ export namespace Markdown {
             '---',
             categories.join(', '),
             '---',
-
-            reqstoolData.svcs_from_req[urn].map((svc) => link(svc, AnnotationType.svc, workspaceKey)).join(', '),
+            svcLinks.join(', '),
         ]
         const markdownText = new MarkdownString(lines.join('\n\n'))
         markdownText.isTrusted = true
@@ -28,6 +30,9 @@ export namespace Markdown {
 
     export function fromSvc(urn: string, reqstoolData: RequirementsToolOutput, workspaceKey: string) {
         const { id, title, description, verification, instructions, revision, requirement_ids } = reqstoolData.svcs[urn]
+        const mvrLinks = ensureStringArray(reqstoolData.mvrs_from_svc?.[urn]).map((svc) =>
+            link(svc, AnnotationType.svc, workspaceKey)
+        )
         const lines = [
             `### ${title}`,
             `\`${id}\` \`${verification}\` \`${stringifyRevision(revision)}\``,
@@ -38,7 +43,7 @@ export namespace Markdown {
             '---',
             requirement_ids.map((req) => link(req, AnnotationType.requirement, workspaceKey)).join(', '),
             '---',
-            reqstoolData.mvrs_from_svc[urn].map((svc) => link(svc, AnnotationType.svc, workspaceKey)).join(', '),
+            mvrLinks.join(', '),
         ]
         const markdownText = new MarkdownString(lines.join('\n\n'))
         markdownText.isTrusted = true

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,3 +30,15 @@ export function setupFileWatcher(reqsDir: URI, handleChange: (uri: URI) => void)
 export function stringifyRevision(revision: Revision) {
     return `${revision.major}.${revision.minor}.${revision.patch}`
 }
+
+/**
+ * Makes sure a object is an actual string array
+ * @param possibleArray The object that may be a string array
+ * @returns The array as is, or an empty array
+ */
+export function ensureStringArray(possibleArray: string[] | undefined) {
+    if (Array.isArray(possibleArray) && possibleArray.every((item) => typeof item === 'string')) {
+        return possibleArray
+    }
+    return []
+}


### PR DESCRIPTION
`reqs_from_urn` and it's siblings may be empty. The error resulting from accessing these prevents the popup from showing. This is now handled before creating the output text by replacing `undefined` values with an empty array.