### PR TITLE
fix: Adds support for annotations spanning multiple lines

### DIFF
--- a/src/ReqsWorkspace.ts
+++ b/src/ReqsWorkspace.ts
@@ -3,7 +3,7 @@
 import * as vscode from 'vscode'
 import { AnnotationType } from './enums/AnnotationType'
 import { expandId, setupFileWatcher } from './util'
-import { RequirementsToolOutput } from './types'
+import { AnnotationId, RequirementsToolOutput } from './types'
 import { keyFrom } from './WorkspaceManager'
 import { Markdown } from './ui/Markdown'
 import { HTML } from './ui/HTML'
@@ -47,34 +47,53 @@ export class ReqsWorkspace {
         return true
     }
 
-    getMarkdown(urn: string, type: AnnotationType) {
-        urn = expandId(urn, this.reqstoolData.initial_model_urn)
+    getMarkdown(id: AnnotationId) {
+        const urn = expandId(id.id, this.reqstoolData.initial_model_urn)
         const key = keyFrom(this.workspaceFolder)
 
-        if (type === AnnotationType.requirement) {
+        if (!this.urnExists(urn, id.type)) {
+            return undefined
+        }
+
+        if (id.type === AnnotationType.requirement) {
             return Markdown.fromRequirement(urn, this.reqstoolData, key)
         }
-        if (type === AnnotationType.svc) {
+        if (id.type === AnnotationType.svc) {
             return Markdown.fromSvc(urn, this.reqstoolData, key)
         }
 
         return undefined
     }
 
-    getHtml(urn: string, type: AnnotationType) {
-        urn = expandId(urn, this.reqstoolData.initial_model_urn)
+    getHtml(id: AnnotationId) {
+        const urn = expandId(id.id, this.reqstoolData.initial_model_urn)
         const key = keyFrom(this.workspaceFolder)
 
-        if (type === AnnotationType.requirement) {
+        if (!this.urnExists(urn, id.type)) {
+            return undefined
+        }
+
+        if (id.type === AnnotationType.requirement) {
             return HTML.fromRequirement(urn, this.reqstoolData, key)
         }
-        if (type === AnnotationType.svc) {
+        if (id.type === AnnotationType.svc) {
             return HTML.fromSvc(urn, this.reqstoolData, key)
         }
-        if (type === AnnotationType.mvr) {
+        if (id.type === AnnotationType.mvr) {
             return HTML.fromMvr(urn, this.reqstoolData, key)
         }
 
         return undefined
+    }
+
+    urnExists(urn: string, type: AnnotationType) {
+        switch (type) {
+            case AnnotationType.requirement:
+                return urn in this.reqstoolData.requirements
+            case AnnotationType.svc:
+                return urn in this.reqstoolData.svcs
+            case AnnotationType.mvr:
+                return urn in this.reqstoolData.mvrs
+        }
     }
 }

--- a/src/WorkspaceManager.ts
+++ b/src/WorkspaceManager.ts
@@ -21,7 +21,7 @@ class WorkspaceManager {
     remove(workspaceFolder: vscode.WorkspaceFolder) {
         const key = keyFrom(workspaceFolder)
         if (!this.reqsWorkspaces.has(key)) {
-            // Not existing in the first place fullfills the goal of "this shall not be".
+            // Not existing in the first place fulfills the goal of "this shall not be".
             return true
         }
         this.reqsWorkspaces.get(key)?.disposeFileWatcher()

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -1,0 +1,96 @@
+// Copyright © LFV
+
+import * as vscode from 'vscode'
+import { AnnotationType } from './enums/AnnotationType'
+import { languageAnnotationMap as keyword } from './languageAnnotationMap'
+import { AnnotationId } from './types'
+
+/**
+ * Get the identifying properties of requirement/SVC that is being hovered, if any.
+ */
+export function getAnnotationId(
+    document: vscode.TextDocument,
+    hoverPosition: vscode.Position
+): AnnotationId | undefined {
+    const result = (idRange: vscode.Range, type: AnnotationType): AnnotationId => {
+        const id = document.getText(idRangeMaybe).slice(1, -1) // Slice away the quotation marks.
+        return { id, type }
+    }
+
+    // First check if what's being hovered is something within double quotes.
+    const idRangeMaybe = document.getWordRangeAtPosition(hoverPosition, /"([^"]*)"/)
+    if (!idRangeMaybe) {
+        // Is not. Can't be what we're looking for.
+        return undefined
+    }
+
+    // Search backwards for a start parenthesis
+    const start = backtrack(document, idRangeMaybe.start)
+    if (!start) {
+        return undefined
+    }
+    // Get word before start of parenthesis
+    const keywordRangeMaybe = document.getWordRangeAtPosition(start.translate(undefined, -3), /@[a-zA-Z]+/)
+
+    // Check keyword against known keywords.
+    // If the keyword matches then the idRangeMaybe can be assumed to be
+    // an actual id.
+    const keywordMaybe = document.getText(keywordRangeMaybe)
+    if (keywordMaybe === keyword[document.languageId].requirements) {
+        return result(idRangeMaybe, AnnotationType.requirement)
+    }
+    if (keywordMaybe === keyword[document.languageId].svcs) {
+        return result(idRangeMaybe, AnnotationType.svc)
+    }
+
+    return undefined
+}
+
+/**
+ * Find the opening parenthesis assuming that the "from" position is within parenthesis. No support for nested parenthesis.
+ * @param fullLine Default false. Whether it should check the full line or start at the "from" position.
+ * @returns Position of the opening parenthesis if found, otherwise undefined.
+ * */
+function backtrack(document: vscode.TextDocument, from: vscode.Position, fullLine = false) {
+    const line = document.lineAt(from).text
+    const start = fullLine ? line.length - 1 : from.character
+
+    for (let i = start; i >= 0; i--) {
+        const match = check(line[i])
+        if (match === Match.Abort) {
+            return undefined
+        }
+        if (match === Match.Yes) {
+            return new vscode.Position(from.line, i)
+        }
+    }
+    // Search previous line
+    if (from.line === 0) {
+        // Previous line can't exist
+        return undefined
+    }
+    return backtrack(document, from.translate(-1), true)
+}
+
+/**
+ * Result from check()
+ */
+enum Match {
+    Yes,
+    No,
+    Abort,
+}
+
+/**
+ * Checks if a character is the start of an annotation arguments parenthesis.
+ */
+function check(char: string) {
+    if (char === '(') {
+        return Match.Yes
+    }
+    // Checks that may help abort the search if we can be sure that we're not within parenthesis.
+    if (char === ')' || char === '=') {
+        return Match.Abort
+    }
+    return Match.No
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@
 import * as vscode from 'vscode'
 import { getReqsDir, scanWorkspaceFolders, setupProject } from './setup'
 import { outputChannel } from './outputChannel'
-import { HoverClickHandlerArgs } from './types'
+import { WorkspaceAnnotation } from './types'
 import { workspaceManager } from './WorkspaceManager'
 import { WebviewProvider } from './WebViewProvider'
 import { AnnotationType } from './enums/AnnotationType'
@@ -32,7 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Register autocomplete snippets
     context.subscriptions.push(registerSnippets())
 
-    // Setup all open workspaces on extension lauch
+    // Setup all open workspaces on extension launch
     scanWorkspaceFolders()
 }
 
@@ -42,12 +42,12 @@ export function deactivate() {
 
 function handleWebViewMessage(message: any) {
     const type = message.type as AnnotationType
-    const html = workspaceManager.getByKey(message.workspaceKey)?.getHtml(message.urn, type)
+    const html = workspaceManager.getByKey(message.workspaceKey)?.getHtml({ id: message.urn, type })
     webView.showWebview(html ?? HTML.fallback(message.urn))
 }
 
-function handleHoverClick(args: HoverClickHandlerArgs) {
-    const html = workspaceManager.getByKey(args.workspaceKey)?.getHtml(args.urn, args.type)
+function handleHoverClick(args: WorkspaceAnnotation) {
+    const html = workspaceManager.getByKey(args.workspaceKey)?.getHtml({ id: args.urn, type: args.type })
     webView.showWebview(html ?? HTML.fallback(args.urn))
 }
 

--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -2,7 +2,7 @@
 
 import * as vscode from 'vscode'
 import { workspaceManager } from './WorkspaceManager'
-import { getAnnotionId } from './annotations'
+import { getAnnotationId } from './annotations'
 
 /**
  * Registers a hover provider for the given languages
@@ -12,7 +12,7 @@ import { getAnnotionId } from './annotations'
 export function registerHoverProvider(languages: string[]) {
     return vscode.languages.registerHoverProvider(languages, {
         provideHover(document, position, token) {
-            const annotation = getAnnotionId(document, position)
+            const annotation = getAnnotationId(document, position)
             if (!annotation) {
                 return
             }

--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -2,9 +2,7 @@
 
 import * as vscode from 'vscode'
 import { workspaceManager } from './WorkspaceManager'
-import { AnnotationPosition } from './types'
-import { languageAnnotationMap } from './languageAnnotationMap'
-import { AnnotationType } from './enums/AnnotationType'
+import { getAnnotionId } from './annotations'
 
 /**
  * Registers a hover provider for the given languages
@@ -14,8 +12,8 @@ import { AnnotationType } from './enums/AnnotationType'
 export function registerHoverProvider(languages: string[]) {
     return vscode.languages.registerHoverProvider(languages, {
         provideHover(document, position, token) {
-            const [id, type] = getAnnotionId(document, position)
-            if (!id || !type) {
+            const annotation = getAnnotionId(document, position)
+            if (!annotation) {
                 return
             }
 
@@ -24,79 +22,11 @@ export function registerHoverProvider(languages: string[]) {
                 return
             }
 
-            const markdown = workspaceManager.getByFolder(folder)?.getMarkdown(id, type)
+            const markdown = workspaceManager
+                .getByFolder(folder)
+                ?.getMarkdown({ id: annotation.id, type: annotation.type })
 
             return new vscode.Hover(markdown ?? '?')
         },
     })
-}
-
-/**
- * Get the ID of requirement/SVC that is being hovered, if any.
- * @returns [id, annorationType]
- */
-function getAnnotionId(document: vscode.TextDocument, hoverPosition: vscode.Position): [string?, AnnotationType?] {
-    const line = document.lineAt(hoverPosition.line).text.trim()
-
-    // Find if/where the requirements start and end
-    const annotation = findAnnotation(line, document.languageId)
-    if (!annotation.type) {
-        return [undefined, undefined]
-    }
-
-    // Abort if the cursor is not within the requirements range
-    if (hoverPosition.character < annotation.start && hoverPosition.character > annotation.end) {
-        return [undefined, undefined]
-    }
-
-    const wordRange = document.getWordRangeAtPosition(hoverPosition, /"([^"]*)"/)
-    if (!wordRange) {
-        return [undefined, undefined]
-    }
-    // Any word within the selection at this point will be an ID wrapped in quotation marks.
-    const id = document.getText(wordRange).slice(1, -1) // Slice away the quotation marks.
-
-    return [id, annotation.type]
-}
-
-/**
- * Find the location of the annotation.
- * @returns Start and end index of the annoration parenthesis. Both values are -1 if the annotation isn't found.
- */
-function findAnnotation(line: string, language: string): AnnotationPosition {
-    // Find keywords
-    const keywordIndex = {
-        requirements: line.indexOf(languageAnnotationMap[language].requirements),
-        svcs: line.indexOf(languageAnnotationMap[language].requirements),
-    }
-
-    // Find coordinates
-    if (keywordIndex.requirements >= 0) {
-        return {
-            type: AnnotationType.requirement,
-            ...findCoordinates(line, keywordIndex.requirements),
-        }
-    }
-
-    if (keywordIndex.svcs >= 0) {
-        return {
-            type: AnnotationType.svc,
-            ...findCoordinates(line, keywordIndex.svcs),
-        }
-    }
-
-    return { start: -1, end: -1 }
-}
-
-/**
- * Finds the start and end index of section within parenthesis of an annoration.
- * @param line
- * @param keywordIndex where it starts looking
- */
-function findCoordinates(line: string, keywordIndex: number) {
-    line = line.substring(keywordIndex)
-    return {
-        start: line.indexOf('('),
-        end: line.indexOf(')'),
-    }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,14 +77,19 @@ type StringArrayMap = {
     [key: string]: string[]
 }
 
-export type HoverClickHandlerArgs = {
+/**
+ * Properties identifying an annotation, id can be just the id, or the urn.
+ */
+export type AnnotationId = {
+    id: string
+    type: AnnotationType
+}
+
+/**
+ * Properties identifying an annotation, including workspace
+ */
+export type WorkspaceAnnotation = {
     urn: string
     type: AnnotationType
     workspaceKey: string
-}
-
-export type AnnotationPosition = {
-    start: number
-    end: number
-    type?: AnnotationType
 }

--- a/src/ui/Markdown.ts
+++ b/src/ui/Markdown.ts
@@ -2,7 +2,7 @@
 
 import { MarkdownString } from 'vscode'
 import { AnnotationType } from '../enums/AnnotationType'
-import { HoverClickHandlerArgs, RequirementsToolOutput } from '../types'
+import { RequirementsToolOutput, WorkspaceAnnotation } from '../types'
 import { ensureStringArray, stringifyRevision } from '../util'
 
 export namespace Markdown {
@@ -61,7 +61,7 @@ export namespace Markdown {
      * The data sent to a vscode command needs to be encoded in a specific way.
      */
     function encodeUrn(urn: string, type: AnnotationType, workspaceKey: string) {
-        const data: HoverClickHandlerArgs = { urn, type, workspaceKey }
+        const data: WorkspaceAnnotation = { urn, type, workspaceKey }
         return encodeURIComponent(JSON.stringify(data))
     }
 }


### PR DESCRIPTION
Fixes the issue where the hover feature would work on the first but not the second line in cases like this:
```java
@Requirements({ "REQ010", "REQ011", 
"REQ025"})
```